### PR TITLE
Implement go mod tidy in common/tools

### DIFF
--- a/multimod/internal/common/tools.go
+++ b/multimod/internal/common/tools.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
+	"path/filepath"
 
 	"golang.org/x/mod/semver"
 
@@ -44,4 +46,18 @@ func ChangeToRepoRoot() (string, error) {
 	}
 
 	return repoRoot, nil
+}
+
+// RunGoModTidy takes a ModulePathMap and runs "go mod tidy" at each module file path.
+func RunGoModTidy(modPathMap ModulePathMap) error {
+	for _, modFilePath := range modPathMap {
+		cmd := exec.Command("go", "mod", "tidy")
+		cmd.Dir = filepath.Dir(string(modFilePath))
+
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("go mod tidy failed: %v\n%v", string(out), err)
+		}
+	}
+
+	return nil
 }

--- a/multimod/internal/prerelease/prerelease.go
+++ b/multimod/internal/prerelease/prerelease.go
@@ -63,7 +63,7 @@ func Run(versioningFile, moduleSetName, fromExistingBranch string, skipGoModTidy
 	if skipGoModTidy {
 		fmt.Println("Skipping 'go mod tidy'...")
 	} else {
-		if err = p.runGoModTidy(); err != nil {
+		if err = common.RunGoModTidy(p.ModuleSetRelease.ModuleVersioning.ModPathMap); err != nil {
 			log.Fatalf("runGoModTidy failed: %v", err)
 		}
 	}
@@ -146,21 +146,6 @@ func (p prerelease) createPrereleaseBranch(fromExistingBranch string) error {
 
 // TODO: updateVersionGo may be implemented to update any hard-coded values within version.go files as needed.
 func (p prerelease) updateVersionGo() error {
-	return nil
-}
-
-// runGoModTidy runs 'go mod tidy' at all module directories to automatically update go.mod and go.sum files.
-// TODO: implement runGoModTidy
-func (p prerelease) runGoModTidy() error {
-	//for _, modFilePath := range p.ModuleSetRelease.ModuleVersioning.ModPathMap {
-	//	cmd := exec.Command("go", "mod", "tidy")
-	//	cmd.Dir = string(modFilePath)
-	//
-	//	if output, err := cmd.CombinedOutput(); err != nil {
-	//		return fmt.Errorf("'go mod tidy' failed: %v (%v)", string(output), err)
-	//	}
-	//}
-
 	return nil
 }
 


### PR DESCRIPTION
Runs "go mod tidy" in the directory of all modified go.mod files.
Removes unimplemented func from prerelease